### PR TITLE
Support floating point numbers when setting and getting current limit

### DIFF
--- a/src/hdecserver.py
+++ b/src/hdecserver.py
@@ -57,7 +57,7 @@ class MyServer(BaseHTTPRequestHandler):
             payload = re.sub(r'mqtt\?payload=(.*)', r'\1', self.path)
             cmd = re.split(r'=', payload)
             if(cmd[0] == "amp" or cmd[0] == "amx"):
-                self.wb.set_current_preset(int(cmd[1]))
+                self.wb.set_current_preset(float(cmd[1]))
                 res = True
             if(cmd[0] == 'alw'):
                 self.wb.allow(cmd[1] != "0")

--- a/src/heidelberg.py
+++ b/src/heidelberg.py
@@ -230,8 +230,8 @@ class wallbox():
         s = {
             "version": "B",
             "car": "{}".format(car),
-            "amp": "{}".format(int(self.get_current_preset())),
-            "amx": "{}".format(int(self.get_current_preset())),
+            "amp": "{}".format(float(self.get_current_preset())),
+            "amx": "{}".format(float(self.get_current_preset())),
             "err": "{}".format(err),
             "ast": "0",
             "alw": "{}".format(1 if self.is_allowed() else 0),


### PR DESCRIPTION
Der Webserver faultet, wenn man eine Dezimalstelle beim amx/amp angibt. Und das aktuelle Limit wird auch nur als int angezeigt (vielleicht in Anlehnung an go-e API?). Jedenfalls ist die PV-Überschuss-Regelung mit dieser Änderung genauer